### PR TITLE
v1.0.2: Smart person search, suppress logs, clean demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.0.2] - 2026-03-26
+
+### Fixed
+- **Person search uses FTS** — `context who` now finds person notes via full-text search instead of exact filename matching. Handles hyphens, underscores, any vault structure. Prefers People folder → `person` tag → fuzzy filename.
+- **llama.cpp logs suppressed** — `backend.void_logs()` silences Metal/model loading output. Clean terminal output by default.
+- **Basename resolution** — `find_file_by_basename` normalizes hyphens/underscores/spaces for cross-format matching.
+
+### Changed
+- Re-recorded demo GIF with v1.0.2 brew binary (clean output, no `2>/dev/null` workarounds)
+
 ## [1.0.1] - 2026-03-26
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "engraph"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engraph"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 description = "Local knowledge graph for AI agents. Hybrid search + MCP server for Obsidian vaults."
 license = "MIT"


### PR DESCRIPTION
## Summary

- **Person search uses FTS** — `context who` finds notes via full-text search, not filename. Handles hyphens, underscores, any vault structure.
- **llama.cpp logs suppressed** — clean terminal output by default.
- **Demo GIF re-recorded** — no `2>/dev/null` workarounds needed.

## Test plan
- [x] `cargo test --lib` — 270 pass
- [x] `cargo clippy` — clean
- [x] `context who 'Sarah Chen'` finds person note
- [x] No llama.cpp log noise in search output
- [ ] CI green
- [ ] Brew upgrade + demo GIF recording after merge