### PR TITLE
fix(temporal): prevent panic on multi-byte UTF-8 queries

### DIFF
--- a/src/temporal.rs
+++ b/src/temporal.rs
@@ -276,6 +276,9 @@ fn find_iso_date_in_query(query: &str) -> Option<(i64, i64)> {
         return None;
     }
     for i in 0..=bytes.len() - 10 {
+        if !query.is_char_boundary(i) || !query.is_char_boundary(i + 10) {
+            continue;
+        }
         let candidate = &query[i..i + 10];
         if candidate.as_bytes()[4] == b'-'
             && candidate.as_bytes()[7] == b'-'


### PR DESCRIPTION
## Summary

- `find_iso_date_in_query()` in `src/temporal.rs` iterates over byte indices (`bytes.len()`) but then slices `&str` using those indices (`&query[i..i + 10]`)
- When the query contains multi-byte UTF-8 characters (e.g. Polish diacritics: ą, ś, ź, ż — each 2 bytes), a byte index can land inside a character, causing a panic at runtime
- Added `is_char_boundary()` guards before slicing to skip non-boundary positions

## Reproducer

```bash
engraph search "powiązania między klientami"
# panicked at src/temporal.rs:279:31:
# byte index 5 is not a char boundary; it is inside 'ą'
```

Any query containing Polish, Czech, German (ü, ö), or other non-ASCII characters at specific byte offsets triggers this.

## Fix

```rust
for i in 0..=bytes.len() - 10 {
    if !query.is_char_boundary(i) || !query.is_char_boundary(i + 10) {
        continue;
    }
    let candidate = &query[i..i + 10];
```

## Test plan

- [x] `engraph search "powiązania między klientami"` — was panic, now returns results
- [x] `engraph search "księgowość rozliczenia"` — was panic, now returns results
- [x] `engraph search "świadczenie usług"` — was panic, now returns results
- [x] ASCII queries still work as before
- [x] `cargo build --release` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)