### PR TITLE
fix(clippy): satisfy Rust 1.95 unnecessary_sort_by + explicit_counter_loop

### DIFF
--- a/src/identity.rs
+++ b/src/identity.rs
@@ -53,7 +53,7 @@ pub fn extract_l1_facts(store: &Store, profile: &VaultProfile) -> Result<L1Summa
                 Some((*f, incoming.len()))
             })
             .collect();
-        scored.sort_by(|a, b| b.1.cmp(&a.1));
+        scored.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         for (file, _count) in scored.into_iter().take(5) {
             let name = file_stem(&file.path);
@@ -71,7 +71,7 @@ pub fn extract_l1_facts(store: &Store, profile: &VaultProfile) -> Result<L1Summa
             .collect();
 
         // Sort by note_date descending (most recent first).
-        daily_files.sort_by(|a, b| b.note_date.cmp(&a.note_date));
+        daily_files.sort_by_key(|b| std::cmp::Reverse(b.note_date));
 
         // ── Current focus (most recent daily note) ──────────────
         if let Some(latest) = daily_files.first()

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -358,15 +358,14 @@ pub fn index_file(
         note_date,
     )?;
 
-    let mut next_vector_id: u64 = store.next_vector_id()?;
+    let start_vector_id: u64 = store.next_vector_id()?;
     let total_chunks = chunks.len();
 
     for (chunk_seq, chunk) in chunks.iter().enumerate() {
         let heading = chunk.heading.clone().unwrap_or_default();
         let snippet = &chunk.snippet;
         let vector = &all_vectors[chunk_seq];
-        let vector_id = next_vector_id;
-        next_vector_id += 1;
+        let vector_id = start_vector_id + chunk_seq as u64;
 
         store.insert_chunk_with_vector(
             file_id,

--- a/src/links.rs
+++ b/src/links.rs
@@ -95,7 +95,7 @@ pub(crate) fn build_name_index(store: &Store, vault_path: &Path) -> Result<Vec<N
     }
 
     // Sort by name length descending — match longer names first
-    entries.sort_by(|a, b| b.name.len().cmp(&a.name.len()));
+    entries.sort_by_key(|b| std::cmp::Reverse(b.name.len()));
     Ok(entries)
 }
 
@@ -701,7 +701,7 @@ pub fn apply_links(content: &str, links: &[DiscoveredLink]) -> String {
     }
 
     // Sort by position descending so we can replace from end to start
-    replacements.sort_by(|a, b| b.0.cmp(&a.0));
+    replacements.sort_by_key(|b| std::cmp::Reverse(b.0));
 
     let mut result = content.to_string();
     for (start, end, replacement) in replacements {

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1039,9 +1039,9 @@ impl LlamaOrchestrator {
         // Each token may produce multi-byte UTF-8 sequences; use an encoding_rs decoder
         // to correctly reassemble them across token boundaries.
         let mut decoder = encoding_rs::UTF_8.new_decoder();
-        let mut n_cur = tokens.len();
+        let prompt_len = tokens.len();
 
-        for _ in 0..max_tokens {
+        for step in 0..max_tokens {
             let new_token = sampler.sample(&ctx, batch.n_tokens() - 1);
             sampler.accept(new_token);
 
@@ -1060,9 +1060,8 @@ impl LlamaOrchestrator {
             // Add token to batch for next iteration.
             batch.clear();
             batch
-                .add(new_token, n_cur as i32, &[0], true)
+                .add(new_token, (prompt_len + step) as i32, &[0], true)
                 .map_err(|e| anyhow::anyhow!("adding generated token to batch: {e}"))?;
-            n_cur += 1;
 
             ctx.decode(&mut batch)
                 .map_err(|e| anyhow::anyhow!("generation decode failed: {e}"))?;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -637,10 +637,9 @@ pub fn create_note(
             None,
         )?;
 
-        let mut next_vid = store.next_vector_id()?;
+        let start_vid = store.next_vector_id()?;
         for (chunk_seq, (heading, snippet, vector, token_count)) in chunk_data.iter().enumerate() {
-            let vid = next_vid;
-            next_vid += 1;
+            let vid = start_vid + chunk_seq as u64;
             store.insert_chunk_with_vector(file_id, heading, snippet, vid, *token_count, vector)?;
             store.insert_vec(vid, vector)?;
             store.insert_fts_chunk(file_id, chunk_seq as i64, snippet)?;
@@ -785,10 +784,9 @@ pub fn append_to_note(
             None,
         )?;
 
-        let mut next_vid = store.next_vector_id()?;
+        let start_vid = store.next_vector_id()?;
         for (chunk_seq, (heading, snippet, vector, token_count)) in chunk_data.iter().enumerate() {
-            let vid = next_vid;
-            next_vid += 1;
+            let vid = start_vid + chunk_seq as u64;
             store.insert_chunk_with_vector(file_id, heading, snippet, vid, *token_count, vector)?;
             store.insert_vec(vid, vector)?;
             store.insert_fts_chunk(file_id, chunk_seq as i64, snippet)?;
@@ -1561,10 +1559,9 @@ pub fn unarchive_note(
             None,
         )?;
 
-        let mut next_vid = store.next_vector_id()?;
+        let start_vid = store.next_vector_id()?;
         for (seq, (heading, snippet, vector, token_count)) in chunk_data.iter().enumerate() {
-            let vid = next_vid;
-            next_vid += 1;
+            let vid = start_vid + seq as u64;
             store.insert_chunk_with_vector(file_id, heading, snippet, vid, *token_count, vector)?;
             store.insert_vec(vid, vector)?;
             store.insert_fts_chunk(file_id, seq as i64, snippet)?;


### PR DESCRIPTION
## Summary

- Rust 1.95 (stable 2026-04-14) promoted `clippy::unnecessary_sort_by` and `clippy::explicit_counter_loop` to deny-by-default via `-D warnings`, breaking CI on PR #24 (macOS+Ubuntu `check` jobs).
- Replace `sort_by(|a, b| b.x.cmp(&a.x))` with `sort_by_key(|b| Reverse(b.x))` in `identity.rs` (2x) and `links.rs` (2x).
- Drop the manual `next_vid += 1` pattern in `indexer.rs`, `writer.rs` (3x), and `llm.rs` — derive the vector id / sequence position from the `enumerate()` index instead.

Once merged, PR #24 should pass CI on re-run (merge commit rebased onto fixed base).

## Test plan
- [x] `cargo clippy -- -D warnings` clean on rustc 1.95.0
- [x] `cargo fmt --check` clean
- [x] `cargo test --lib` — 458 passed, 0 failed