### PR TITLE
chore(deps): bump rmcp 1.4 -> 1.5 (MCP protocol 2025-11-25)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2015,9 +2015,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rayon = "1"
 time = { version = "0.3", features = ["parsing", "formatting", "macros"] }
 strsim = "0.11"
 ignore = "0.4"
-rmcp = { version = "1.4", features = ["transport-io"] }
+rmcp = { version = "1.5", features = ["transport-io"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "process", "time", "net"] }
 notify = "7.0"
 notify-debouncer-full = "0.4"


### PR DESCRIPTION
## Summary

- Bumps `rmcp` 1.4.0 → 1.5.0 (released 2026-04-16).
- rmcp 1.5.0 adds MCP protocol version `2025-11-25` via upstream [modelcontextprotocol/rust-sdk#802](https://github.com/modelcontextprotocol/rust-sdk/pull/802). This is the version Claude Desktop's Cowork and Code-in-Desktop modes require to surface MCP tools.
- No source changes needed — API-compatible patch upgrade for our usage. Only `Cargo.toml` + `Cargo.lock` change (plus the clippy fixes inherited from #29 while that's still unmerged; diff will shrink to just the deps once #29 lands).

Fixes #20.

## Test plan
- [x] `cargo build --release` succeeds (1m38s)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib` — 458 passed, 0 failed
- [x] Smoke test: stdio `initialize` handshake requesting `2025-11-25` now returns `protocolVersion: "2025-11-25"` (was `"2025-06-18"` on rmcp 1.4) and `serverInfo.version: "1.5.0"`
- [ ] Manual: verify engraph now surfaces tools inside Claude Desktop Cowork / Code-in-Desktop after `brew upgrade`

## Stacking note

This branch is based on #29 (`fix/clippy-rust-1.95`). Merge #29 first; this PR's diff will automatically reduce to just `Cargo.toml` + `Cargo.lock` after rebase-or-merge to main.