### PR TITLE
Add Agent Skill and Claude Marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "engraph",
       "source": "./",
       "description": "Turn your Markdown vault into a searchable knowledge graph that any AI agent can query.",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "author": {
         "name": "devwhodevs",
         "email": "devwhodevs@gmail.com"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,35 @@
+{
+  "name": "engraph",
+  "owner": {
+    "name": "devwhodevs",
+    "email": "devwhodevs@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "engraph",
+      "source": "./",
+      "description": "Turn your Markdown vault into a searchable knowledge graph that any AI agent can query.",
+      "version": "0.1.0",
+      "author": {
+        "name": "devwhodevs",
+        "email": "devwhodevs@gmail.com"
+      },
+      "repository": "https://github.com/devwhodevs/engraph",
+      "license": "MIT",
+      "keywords": [
+        "markdown",
+        "search",
+        "engraph",
+        "graph search",
+        "knowledge graph"
+      ],
+      "skills": ["./skills/"],
+      "mcpServers": {
+        "engraph": {
+          "command": "engraph",
+          "args": ["serve"]
+        }
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ engraph serve
 
 Now Claude can search your vault, read notes, build context bundles, and create new notes — all through structured tool calls.
 
+**AI Agent Skills** — Install the Engraph skills using the skills CLI (recommended):
+
+```bash
+npx skills add devwhodevs/engraph
+```
+
 **Enable HTTP REST API:**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -114,13 +114,18 @@ engraph search "how does the auth system work"
 
 Note how result #3 was found via **graph expansion** — Sarah's note doesn't mention "auth system" directly, but she's linked from the auth architecture doc via `[[Sarah Chen]]`.
 
-**Connect to Claude Code:**
+**Claude Code** — Install the plugin (recommended):
 
 ```bash
-# Start the MCP server
-engraph serve
+claude plugin marketplace add devwhodevs/engraph
+claude plugin install engraph@engraph
+```
 
-# Or add to Claude Code's settings (~/.claude/settings.json):
+**Connect to Claude Code:**
+
+Or configure MCP manually in `~/.claude/settings.json`:
+
+```bash
 {
   "mcpServers": {
     "engraph": {

--- a/skills/engraph/SKILL.md
+++ b/skills/engraph/SKILL.md
@@ -22,8 +22,8 @@ Local knowledge engine for markdown document collections. Combines semantic embe
 ```bash
 engraph index /path/to/documents        # Incremental; only changed files re-embedded
 engraph index /path/to/documents --rebuild
-engraph status                          # File count, health, stats
-engraph clear                           # Drop cached data and models
+engraph status                          # File count, stats, index freshness
+engraph clear                           # Drop the index (--all also removes models)
 ```
 
 ## Search
@@ -60,11 +60,12 @@ engraph graph stats                     # Nodes, edges, density
 engraph context topic "authentication" --budget 8000
 engraph context who "Person Name"
 engraph context project "Project Name"
-engraph context vault-map               # Collection structure overview
-engraph context health                  # Orphans, broken links, stale content, tag hygiene
-engraph context read "path/to/note.md"  # Full content + metadata
-engraph context list --tag architecture # Filter by tag, folder, created_by, etc.
+engraph context vault-map                 # Collection structure overview
+engraph context read "path/to/note.md"    # Full content + metadata
+engraph context list --tags architecture  # Filter by tags, folder, created_by, etc.
 ```
+
+> Health diagnostics (orphans, broken links, stale notes, tag hygiene) are exposed through the MCP `health` tool and the HTTP `GET /api/health` endpoint — see `references/http-rest-api.md`.
 
 ## Setup
 
@@ -72,3 +73,8 @@ engraph context list --tag architecture # Filter by tag, folder, created_by, etc
 engraph index /path/to/documents
 engraph search "your query"
 ```
+
+## References
+
+- `references/mcp-setup.md` — configure engraph as an MCP server (Claude Code, Claude Desktop).
+- `references/http-rest-api.md` — HTTP REST API endpoints, authentication, and examples for web agents and scripts.

--- a/skills/engraph/SKILL.md
+++ b/skills/engraph/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: engraph
+description: Index and search document collections using hybrid semantic + graph + full-text search. Use when users need to search knowledge bases, find connections between documents, discover related content via link graphs, or query indexed markdown collections.
+license: MIT
+compatibility: Requires engraph CLI. Install via `brew install devwhodevs/tap/engraph` or from GitHub releases.
+metadata:
+  author: jsynowiec
+  version: "1.0.0"
+allowed-tools: Bash(engraph:*), mcp__engraph__*
+---
+
+# Engraph — Hybrid Semantic & Graph Search for Document Collections
+
+Local knowledge engine for markdown document collections. Combines semantic embeddings, full-text search (BM25), wikilink graph traversal, temporal scoring, and cross-encoder reranking.
+
+## Status
+
+!`engraph status 2>/dev/null || echo "Not installed: brew install devwhodevs/tap/engraph"`
+
+## Indexing
+
+```bash
+engraph index /path/to/documents        # Incremental; only changed files re-embedded
+engraph index /path/to/documents --rebuild
+engraph status                          # File count, health, stats
+engraph clear                           # Drop cached data and models
+```
+
+## Search
+
+```bash
+engraph search "how does the auth flow work"
+engraph search "performance regressions last month" --explain
+engraph search "architecture decisions" -n 5 --json
+```
+
+| Flag              | Description                                    |
+| ----------------- | ---------------------------------------------- |
+| `-n, --top-n <N>` | Number of results (default: from config or 10) |
+| `--explain`       | Show per-lane RRF score breakdown              |
+| `--json`          | Machine-readable JSON output                   |
+
+### Query Tips
+
+- **Conceptual / vague**: Use natural language. The orchestrator classifies intent and boosts semantic weight automatically.
+- **Keyword-heavy**: Exact terms, identifiers, and names work well via the BM25 lane.
+- **Temporal**: "last week", "yesterday", "March 2026" — the temporal lane activates automatically.
+
+## Graph Inspection
+
+```bash
+engraph graph show "path/to/note.md"    # Connections for a document
+engraph graph show "#docid"             # By document ID
+engraph graph stats                     # Nodes, edges, density
+```
+
+## Context Queries
+
+```bash
+engraph context topic "authentication" --budget 8000
+engraph context who "Person Name"
+engraph context project "Project Name"
+engraph context vault-map               # Collection structure overview
+engraph context health                  # Orphans, broken links, stale content, tag hygiene
+engraph context read "path/to/note.md"  # Full content + metadata
+engraph context list --tag architecture # Filter by tag, folder, created_by, etc.
+```
+
+## Setup
+
+```bash
+engraph index /path/to/documents
+engraph search "your query"
+```

--- a/skills/engraph/SKILL.md
+++ b/skills/engraph/SKILL.md
@@ -15,7 +15,7 @@ Local knowledge engine for markdown document collections. Combines semantic embe
 
 ## Status
 
-!`engraph status 2>/dev/null || echo "Not installed: brew install devwhodevs/tap/engraph"`
+!`engraph --version 2>/dev/null || echo "Not installed: brew install devwhodevs/tap/engraph"`
 
 ## Indexing
 

--- a/skills/engraph/references/http-rest-api.md
+++ b/skills/engraph/references/http-rest-api.md
@@ -38,5 +38,5 @@ Generate keys:
 ```bash
 engraph configure --add-api-key       # Interactive
 engraph configure --list-api-keys     # List existing
-engraph configure --revoke-api-key    # Revoke
+engraph configure --revoke-api-key <name>  # Revoke a key by name
 ```

--- a/skills/engraph/references/http-rest-api.md
+++ b/skills/engraph/references/http-rest-api.md
@@ -1,0 +1,42 @@
+# Engraph HTTP REST API
+
+Enable alongside MCP for web agents, scripts, and integrations:
+
+```bash
+engraph serve --http              # Default port 3000
+engraph serve --http --port 8080 --host 0.0.0.0
+engraph serve --http --no-auth    # Local dev only (127.0.0.1)
+```
+
+## Key Endpoints
+
+| Method | Endpoint                | Description                                                      |
+| ------ | ----------------------- | ---------------------------------------------------------------- |
+| POST   | `/api/search`           | Hybrid search with semantic + FTS5 + graph + reranker + temporal |
+| GET    | `/api/read/{file}`      | Read full document content + metadata                            |
+| GET    | `/api/read-section`     | Read specific section by heading                                 |
+| GET    | `/api/list`             | List documents with tag/folder filters                           |
+| GET    | `/api/vault-map`        | Collection structure overview                                    |
+| POST   | `/api/context`          | Rich topic context with token budget                             |
+| GET    | `/api/health`           | Collection health diagnostics                                    |
+| POST   | `/api/create`           | Create new document                                              |
+| POST   | `/api/edit`             | Section-level editing                                            |
+| POST   | `/api/rewrite`          | Full body rewrite (preserves frontmatter)                        |
+| POST   | `/api/edit-frontmatter` | Granular frontmatter mutations                                   |
+
+## Authentication
+
+All HTTP requests require an API key via the `Authorization` header:
+
+```bash
+curl -H "Authorization: Bearer eg_abc123..." http://localhost:3000/api/search \
+  -H "Content-Type: application/json" -d '{"query": "architecture", "top_n": 5}'
+```
+
+Generate keys:
+
+```bash
+engraph configure --add-api-key       # Interactive
+engraph configure --list-api-keys     # List existing
+engraph configure --revoke-api-key    # Revoke
+```

--- a/skills/engraph/references/mcp-setup.md
+++ b/skills/engraph/references/mcp-setup.md
@@ -32,5 +32,5 @@ engraph index /path/to/documents
 ## HTTP Mode
 
 ```bash
-engraph serve --http              # Port 3030
+engraph serve --http              # Port 3000
 ```

--- a/skills/engraph/references/mcp-setup.md
+++ b/skills/engraph/references/mcp-setup.md
@@ -1,0 +1,36 @@
+# Engraph MCP Server Setup
+
+## Install
+
+```bash
+brew install devwhodevs/tap/engraph
+engraph index /path/to/documents
+```
+
+## Configure MCP Client
+
+**Claude Code** (`~/.claude/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "engraph": { "command": "engraph", "args": ["serve"] }
+  }
+}
+```
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "engraph": { "command": "engraph", "args": ["serve"] }
+  }
+}
+```
+
+## HTTP Mode
+
+```bash
+engraph serve --http              # Port 3030
+```


### PR DESCRIPTION
## Summary

Adds a new engraph agent skill that exposes engraph's capabilities to AI agents and applications supporting agent skills. Also includes marketplace registration and validation that the engraph CLI is installed before allowing tool use.

@devwhodevs I've listed you in the marketplace, but myself in the skill. Hope that's fine.

## Use case this solves

I'm using this skill myself alongside qmd to search through my Markdown vaults. I'm mostly using this with pi but it'll work with any agent.

## Verification

- [x] I'm using the skill myself and I think it's already good enough. Haven't changed anything for a while.
- [x] I've installed the Claude marketplace plugin locally, tested the MCP and skill, both are working.
- [x] I've installed the skill using the `npx skill` and it worked.

However, best to check both the Claude marketplace and the Vercel Skills after this is merged to main. It should work, but the maintainer/repository path changes, and I can't simulate that.