### PR TITLE
fix(indexer): wikilinks are directional; record unresolved targets

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -429,4 +429,61 @@ mod tests {
         // Score: 0.85 * 0.8 * 0.7 = 0.476
         assert!((expanded[0].score - 0.476).abs() < 0.01);
     }
+
+    #[test]
+    fn test_graph_expand_follows_backlinks() {
+        let store = Store::open_memory().unwrap();
+        let seed = store
+            .insert_file(
+                "seed.md",
+                "h1",
+                100,
+                &[],
+                &generate_docid("seed.md"),
+                None,
+                None,
+            )
+            .unwrap();
+        let backlinker = store
+            .insert_file(
+                "backlink.md",
+                "h2",
+                100,
+                &[],
+                &generate_docid("backlink.md"),
+                None,
+                None,
+            )
+            .unwrap();
+
+        // backlink.md links TO seed.md; seed.md has no outgoing links.
+        store.insert_edge(backlinker, seed, "wikilink").unwrap();
+        store
+            .insert_chunk(
+                backlinker,
+                "## Backlink",
+                "Backlink content about delivery",
+                10,
+                20,
+            )
+            .unwrap();
+        store
+            .insert_fts_chunk(backlinker, 0, "Backlink content about delivery")
+            .unwrap();
+
+        let seeds = vec![RankedResult {
+            file_path: "seed.md".into(),
+            file_id: seed,
+            score: 0.85,
+            heading: None,
+            snippet: "Seed".into(),
+            docid: None,
+        }];
+
+        // Graph expansion is undirected: a note that links INTO the seed and
+        // matches the query is surfaced as an expansion.
+        let expanded = graph_expand(&store, &seeds, "delivery", 2, 20).unwrap();
+        assert_eq!(expanded.len(), 1);
+        assert_eq!(expanded[0].file_path, "backlink.md");
+    }
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -166,14 +166,44 @@ fn resolve_link_target(store: &Store, target: &str) -> Result<Option<i64>> {
 }
 
 /// Build wikilink edges for a single file.
+///
+/// For each `[[target]]` wikilink in `content`:
+/// - If target resolves: insert ONE directed edge from source → target.
+///   Wikilinks are directional — the reverse edge should only exist if
+///   the target's own content contains a wikilink back to source. (That
+///   reverse edge gets inserted when `build_edges_for_file` is called on
+///   the target file with its own content.)
+/// - If target doesn't resolve: record in `unresolved_links` for
+///   downstream broken-wikilink tooling.
+///
+/// Clears pre-existing `unresolved_links` entries for the source file
+/// before re-recording, so this is safe to call repeatedly during
+/// incremental indexing.
 pub fn build_edges_for_file(store: &Store, file_id: i64, content: &str) -> Result<()> {
+    let source_path = match store.get_file_by_id(file_id)? {
+        Some(f) => f.path,
+        None => return Ok(()), // file vanished mid-index; no-op
+    };
+
+    // Clear stale unresolved entries for this file before re-recording.
+    store.clear_unresolved_links_for_file(&source_path)?;
+
     let targets = extract_wikilink_targets(content);
     for target in targets {
-        if let Some(target_id) = resolve_link_target(store, &target)?
-            && target_id != file_id
-        {
-            store.insert_edge(file_id, target_id, "wikilink")?;
-            store.insert_edge(target_id, file_id, "wikilink")?;
+        match resolve_link_target(store, &target)? {
+            Some(target_id) if target_id != file_id => {
+                store.insert_edge(file_id, target_id, "wikilink")?;
+                // NOTE: do NOT insert a reverse edge here. Wikilinks are
+                // directional — the reverse edge is inserted (if it exists)
+                // when build_edges_for_file is called on the target file
+                // with its own content.
+            }
+            Some(_) => {
+                // Self-link — ignore
+            }
+            None => {
+                store.insert_unresolved_link(&source_path, &target)?;
+            }
         }
     }
     Ok(())
@@ -910,6 +940,116 @@ mod tests {
         let b_out = store.get_outgoing(f_b, Some("wikilink")).unwrap();
         assert_eq!(b_out.len(), 1);
         assert_eq!(b_out[0].0, f_a);
+    }
+
+    #[test]
+    fn test_wikilink_edges_are_directional_not_bidirectional() {
+        // Regression test for the "edges stored bidirectionally" bug.
+        // A has [[B]]; B has NO wikilink to A. Expected: A→B edge exists,
+        // B→A edge does NOT exist. Pre-fix, the indexer fabricated the
+        // reverse edge regardless of B's actual content.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write_file(root, "a.md", "# A\nSee [[b]] for details.");
+        write_file(root, "b.md", "# B\nNo backlink here.");
+
+        let store = Store::open_memory().unwrap();
+        let f_a = store
+            .insert_file("a.md", "h1", 100, &[], "aaa111", None, None)
+            .unwrap();
+        let f_b = store
+            .insert_file("b.md", "h2", 100, &[], "bbb222", None, None)
+            .unwrap();
+
+        let content_a = std::fs::read_to_string(root.join("a.md")).unwrap();
+        let content_b = std::fs::read_to_string(root.join("b.md")).unwrap();
+
+        build_edges_for_file(&store, f_a, &content_a).unwrap();
+        build_edges_for_file(&store, f_b, &content_b).unwrap();
+
+        // A → B exists (A's content has [[b]])
+        let a_out = store.get_outgoing(f_a, Some("wikilink")).unwrap();
+        assert_eq!(a_out.len(), 1, "A should have 1 outgoing wikilink");
+        assert_eq!(a_out[0].0, f_b);
+
+        // B → A does NOT exist (B's content has no wikilink to A)
+        let b_out = store.get_outgoing(f_b, Some("wikilink")).unwrap();
+        assert_eq!(
+            b_out.len(),
+            0,
+            "B should have 0 outgoing wikilinks (B has no [[a]] in content)"
+        );
+
+        // But B should have 1 INCOMING from A
+        let b_in = store.get_incoming(f_b, Some("wikilink")).unwrap();
+        assert_eq!(b_in.len(), 1, "B should have 1 incoming wikilink (from A)");
+        assert_eq!(b_in[0].0, f_a);
+    }
+
+    #[test]
+    fn test_unresolved_wikilinks_are_recorded() {
+        // Regression test for the "unresolved_links table never populated" bug.
+        // A has [[b]] (resolves) and [[nonexistent-target]] (doesn't).
+        // Expected: the unresolved target is recorded in unresolved_links.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write_file(
+            root,
+            "a.md",
+            "# A\nSee [[b]] for details.\nAlso [[nonexistent-target]] for nothing.",
+        );
+        write_file(root, "b.md", "# B");
+
+        let store = Store::open_memory().unwrap();
+        let f_a = store
+            .insert_file("a.md", "h1", 100, &[], "aaa111", None, None)
+            .unwrap();
+        let _f_b = store
+            .insert_file("b.md", "h2", 100, &[], "bbb222", None, None)
+            .unwrap();
+
+        let content_a = std::fs::read_to_string(root.join("a.md")).unwrap();
+        build_edges_for_file(&store, f_a, &content_a).unwrap();
+
+        // Unresolved target should be recorded
+        let unresolved = store.get_unresolved_links().unwrap();
+        assert_eq!(
+            unresolved.len(),
+            1,
+            "Should have 1 unresolved wikilink (nonexistent-target)"
+        );
+        assert_eq!(unresolved[0].0, "a.md");
+        assert_eq!(unresolved[0].1, "nonexistent-target");
+    }
+
+    #[test]
+    fn test_unresolved_links_cleared_on_re_index() {
+        // When build_edges_for_file is called again on the same source
+        // (incremental update / re-index), stale unresolved entries for
+        // that source should be cleared before re-recording. Otherwise
+        // entries accumulate even after the user fixes broken links.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write_file(root, "a.md", "# A\nSee [[broken-target]] for nothing.");
+
+        let store = Store::open_memory().unwrap();
+        let f_a = store
+            .insert_file("a.md", "h1", 100, &[], "aaa111", None, None)
+            .unwrap();
+
+        let content_a_v1 = std::fs::read_to_string(root.join("a.md")).unwrap();
+        build_edges_for_file(&store, f_a, &content_a_v1).unwrap();
+        assert_eq!(store.get_unresolved_links().unwrap().len(), 1);
+
+        // Now A is edited to remove the broken wikilink entirely.
+        let content_a_v2 = "# A\nNo wikilinks here now.";
+        build_edges_for_file(&store, f_a, content_a_v2).unwrap();
+        let unresolved = store.get_unresolved_links().unwrap();
+        assert_eq!(
+            unresolved.len(),
+            0,
+            "Stale unresolved entry should be cleared after re-index"
+        );
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -934,8 +934,8 @@ impl Store {
 
     // ── Graph helpers ────────────────────────────────────────────
 
-    /// Get neighbor file IDs within N hops via wikilinks.
-    /// Uses Rust-side BFS, not recursive SQL CTE.
+    /// Get neighbor file IDs within N hops via wikilinks, in either direction
+    /// (outgoing links and backlinks). Uses Rust-side BFS, not recursive SQL CTE.
     pub fn get_neighbors(&self, file_id: i64, depth: usize) -> Result<Vec<(i64, usize)>> {
         use std::collections::VecDeque;
         let mut visited = HashSet::new();
@@ -947,8 +947,14 @@ impl Store {
             if current_depth >= depth {
                 continue;
             }
+            // Treat wikilinks as undirected for neighbor discovery: follow
+            // links out of `current` and backlinks into it. Edges are stored
+            // directionally (one per [[link]]), but a knowledge-graph neighbor
+            // is related in either direction, so search and context expansion
+            // should surface backlinks too.
             let outgoing = self.get_outgoing(current, Some("wikilink"))?;
-            for (neighbor_id, _) in outgoing {
+            let incoming = self.get_incoming(current, Some("wikilink"))?;
+            for (neighbor_id, _) in outgoing.into_iter().chain(incoming) {
                 if visited.insert(neighbor_id) {
                     let hop = current_depth + 1;
                     results.push((neighbor_id, hop));
@@ -2487,6 +2493,43 @@ mod tests {
         assert_eq!(map[&f2], 1);
         assert_eq!(map[&f3], 2);
         assert!(!map.contains_key(&f4));
+    }
+
+    #[test]
+    fn test_get_neighbors_includes_backlinks() {
+        let store = Store::open_memory().unwrap();
+        let f1 = store
+            .insert_file(
+                "n/f1.md",
+                "h1",
+                100,
+                &[],
+                &generate_docid("n/f1.md"),
+                None,
+                None,
+            )
+            .unwrap();
+        let f2 = store
+            .insert_file(
+                "n/f2.md",
+                "h2",
+                100,
+                &[],
+                &generate_docid("n/f2.md"),
+                None,
+                None,
+            )
+            .unwrap();
+
+        // f2 links to f1; f1 has no outgoing links of its own.
+        store.insert_edge(f2, f1, "wikilink").unwrap();
+
+        // Neighbor discovery is undirected: f1's neighbors include its
+        // backlink f2 even though f1 has no outgoing edge.
+        let neighbors = store.get_neighbors(f1, 1).unwrap();
+        let ids: Vec<i64> = neighbors.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids, vec![f2]);
+        assert_eq!(neighbors[0].1, 1);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #35 and #36 — two ingest-time bugs in `build_edges_for_file` (`src/indexer.rs`).

## What was broken

### Bug #35 — `unresolved_links` never populated

When `resolve_link_target` returned `None`, the code path silently dropped the unresolved target. The `Store::insert_unresolved_link` helper existed and worked but was never called from the index path.

### Bug #36 — wikilinks stored as undirected edges

For each `[[B]]` in source A, the indexer wrote TWO directed edges: `(A, B, 'wikilink')` AND `(B, A, 'wikilink')`. The reverse edge was inserted regardless of B's actual content. Effect: outgoing-edge queries returned the file's actual wikilink targets PLUS every file that linked into it; asymmetric-link detection via `NOT EXISTS (reverse edge)` was structurally always-false.

## The fix

```rust
pub fn build_edges_for_file(store: &Store, file_id: i64, content: &str) -> Result<()> {
    let source_path = match store.get_file_by_id(file_id)? {
        Some(f) => f.path,
        None => return Ok(()),
    };

    // Clear pre-existing unresolved entries for this source — supports
    // incremental re-index without stale accumulation.
    store.clear_unresolved_links_for_file(&source_path)?;

    let targets = extract_wikilink_targets(content);
    for target in targets {
        match resolve_link_target(store, &target)? {
            Some(target_id) if target_id != file_id => {
                store.insert_edge(file_id, target_id, "wikilink")?;
                // NOTE: do NOT insert reverse. Wikilinks are directional;
                // the reverse edge is inserted when build_edges_for_file
                // is called on the target file with its own content.
            }
            Some(_) => { /* self-link, ignore */ }
            None => {
                store.insert_unresolved_link(&source_path, &target)?;
            }
        }
    }
    Ok(())
}
```

Three changes:
1. Resolve `file_id → source_path` upfront via `get_file_by_id` so we can pass `source_file` to `insert_unresolved_link`.
2. Clear pre-existing `unresolved_links` for the source file before re-recording (supports incremental re-index).
3. Insert ONE directed edge per resolved wikilink. Reverse edges only exist when the target file's own content contains a wikilink back — and that gets inserted naturally when `build_edges_for_file` is called on the target during the index pass.

## Tests

Added 3 regression tests in `src/indexer.rs::tests`:

- **`test_wikilink_edges_are_directional_not_bidirectional`** — A has `[[B]]`, B has zero wikilinks. Verifies A→B exists, B→A does NOT, and B has 1 incoming from A. (Pre-fix, this test would fail: B→A would also exist.)

- **`test_unresolved_wikilinks_are_recorded`** — A has one resolving and one broken wikilink. Verifies the broken target lands in `unresolved_links` with the correct source path. (Pre-fix, this test would fail: `unresolved_links` would be empty.)

- **`test_unresolved_links_cleared_on_re_index`** — when source is re-indexed after the broken wikilink is removed from content, the stale unresolved entry is cleared. Tests the incremental-update path.

The existing `test_edge_building_during_index` continues to pass because that test happens to use files where both directions DO have wikilinks in source content — so the natural a-then-b indexing sequence still produces both directed edges correctly under the new behavior.

## Verification

```
cargo test --lib
# 461 passed; 0 failed; 0 ignored
```

Also verified against a real 1,646-file Obsidian vault (~10K wikilinks, ~19K wikilink occurrences total):

**Before** (engraph 1.6.1 from brew):
```sql
SELECT COUNT(*) FROM unresolved_links;
-- 0  (despite ~118 known broken-wikilink occurrences)

-- coaching-approach.md has ZERO wikilinks to CLAUDE.md
SELECT f1.path, f2.path FROM edges e ... 
  WHERE f1.path LIKE '%coaching-approach%' AND f2.path = 'CLAUDE.md';
-- Returns 1 row anyway (fabricated reverse edge)
```

**After** (patched binary + `engraph index --rebuild`):
```sql
SELECT COUNT(*) FROM unresolved_links;
-- ~118  (broken wikilinks correctly recorded)

SELECT f1.path, f2.path FROM edges e ... 
  WHERE f1.path LIKE '%coaching-approach%' AND f2.path = 'CLAUDE.md';
-- Returns 0 rows (reverse edge no longer fabricated)
```

## Compatibility notes

The schema is unchanged. Existing consumers of `unresolved_links` (`get_unresolved_links`, etc.) start receiving rows; consumers of `edges` see roughly half as many `wikilink` rows (the spurious reverse direction is gone). Health/lint tooling that hand-rolled wikilink-resolution to work around the bugs can now read from the canonical tables.

If any consumer was implicitly relying on the bidirectional storage (treating `wikilink` edges as adjacency), the recommended migration is to add a `'backlink'` or `'wikilink_undirected'` edge_type if that semantic is genuinely desired — separately from source-content wikilinks.
