### PR TITLE
fix: trust system CA for model downloads + optional .gitignore bypass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,6 +439,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,6 +1741,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2075,6 +2091,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,6 +2154,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2186,29 @@ dependencies = [
  "quote",
  "serde_derive_internals",
  "syn",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2790,6 +2860,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.11",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokenizers = { version = "0.22", default-features = false, features = ["fancy-regex"] }
 sha2 = "0.10"
-ureq = "2.12"
+ureq = { version = "2.12", features = ["native-certs"] }
 indicatif = "0.17"
 dialoguer = "0.12"
 console = "0.16"

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,6 +123,9 @@ pub struct Config {
     pub exclude: Vec<String>,
     /// Number of files to process per embedding batch.
     pub batch_size: usize,
+    /// Honor `.gitignore` / `.ignore` files when walking the vault. Set false
+    /// to index files those VCS rules would otherwise skip.
+    pub respect_gitignore: bool,
     /// Whether intelligence features are enabled. None = not yet configured.
     pub intelligence: Option<bool>,
     /// Model override URIs.
@@ -149,6 +152,7 @@ impl Default for Config {
             top_n: 5,
             exclude: vec![".obsidian/".to_string()],
             batch_size: 64,
+            respect_gitignore: true,
             intelligence: None,
             models: ModelConfig::default(),
             obsidian: ObsidianConfig::default(),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -34,12 +34,31 @@ pub struct IndexFileResult {
 
 /// Walk a vault directory and collect all `.md` file paths.
 ///
-/// Uses the `ignore` crate so `.gitignore` rules are respected automatically.
-/// Additional exclude patterns (e.g. `.obsidian/`) are applied on top.
-pub fn walk_vault(path: &Path, exclude: &[String]) -> Result<Vec<PathBuf>> {
-    let walker = WalkBuilder::new(path)
-        .standard_filters(true) // respect .gitignore, .ignore, etc.
-        .build();
+/// When `respect_gitignore` is true, the `ignore` crate honors `.gitignore` /
+/// `.ignore` rules (within a git repo, per the crate's `require_git` default).
+/// Set it false to index files those VCS rules would skip; hidden entries
+/// (`.git/`, dotfiles) and the explicit `exclude` patterns are always skipped.
+pub fn walk_vault(
+    path: &Path,
+    exclude: &[String],
+    respect_gitignore: bool,
+) -> Result<Vec<PathBuf>> {
+    let mut builder = WalkBuilder::new(path);
+    if respect_gitignore {
+        builder.standard_filters(true); // respect .gitignore, .ignore, hidden, etc.
+    } else {
+        // Stop honoring .gitignore / .ignore so VCS-ignored files get indexed,
+        // but still skip hidden entries (.git/, dotfiles) and apply the
+        // explicit exclude patterns below.
+        builder
+            .hidden(true)
+            .parents(true)
+            .git_ignore(false)
+            .git_global(false)
+            .git_exclude(false)
+            .ignore(false);
+    }
+    let walker = builder.build();
 
     let mut files = Vec::new();
     for entry in walker {
@@ -548,7 +567,7 @@ fn run_index_inner(
     }
 
     // If rebuild, treat everything as new.
-    let files = walk_vault(vault_path, &exclude)?;
+    let files = walk_vault(vault_path, &exclude, config.respect_gitignore)?;
 
     let (new_files, changed_files, deleted_files) = if rebuild {
         // On rebuild we skip diffing — all files are "new".
@@ -753,7 +772,7 @@ mod tests {
         write_file(root, "image.png", "not markdown");
         write_file(root, "readme.txt", "text file");
 
-        let files = walk_vault(root, &[]).unwrap();
+        let files = walk_vault(root, &[], true).unwrap();
         assert_eq!(files.len(), 3, "expected 3 .md files, got {:?}", files);
         for f in &files {
             assert_eq!(f.extension().unwrap(), "md");
@@ -768,7 +787,7 @@ mod tests {
         write_file(root, ".obsidian/workspace.md", "obsidian internal");
         write_file(root, ".obsidian/plugins/plugin.md", "plugin data");
 
-        let files = walk_vault(root, &[".obsidian/".to_string()]).unwrap();
+        let files = walk_vault(root, &[".obsidian/".to_string()], true).unwrap();
         assert_eq!(files.len(), 1, "expected 1 file, got {:?}", files);
         assert!(files[0].ends_with("note.md"));
     }
@@ -789,7 +808,7 @@ mod tests {
         write_file(root, "note.md", "# Note");
         write_file(root, "drafts/note.md", "# Draft");
 
-        let files = walk_vault(root, &[]).unwrap();
+        let files = walk_vault(root, &[], true).unwrap();
         assert_eq!(
             files.len(),
             1,
@@ -800,6 +819,48 @@ mod tests {
     }
 
     #[test]
+    fn test_walk_gitignore_toggle() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        // Git repo so the ignore crate honors .gitignore (require_git default).
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(root)
+            .output()
+            .expect("git init failed");
+
+        write_file(root, ".gitignore", "drafts/\n");
+        write_file(root, "note.md", "# Note");
+        write_file(root, "drafts/draft.md", "# Draft");
+
+        // respect_gitignore = true: the gitignored dir is skipped.
+        let respected = walk_vault(root, &[], true).unwrap();
+        assert_eq!(
+            respected.len(),
+            1,
+            "gitignored dir should be skipped, got {:?}",
+            respected
+        );
+        assert!(respected[0].ends_with("note.md"));
+
+        // respect_gitignore = false: the gitignored file is indexed too.
+        let ignored = walk_vault(root, &[], false).unwrap();
+        let names: Vec<String> = ignored
+            .iter()
+            .map(|f| f.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            ignored.len(),
+            2,
+            "expected gitignored file to be included, got {:?}",
+            ignored
+        );
+        assert!(names.contains(&"note.md".to_string()));
+        assert!(names.contains(&"draft.md".to_string()));
+    }
+
+    #[test]
     fn test_detect_new_files() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
@@ -807,7 +868,7 @@ mod tests {
         write_file(root, "b.md", "# B");
 
         let store = Store::open_memory().unwrap();
-        let files = walk_vault(root, &[]).unwrap();
+        let files = walk_vault(root, &[], true).unwrap();
         let (new, changed, deleted) = diff_vault(&files, root, &store).unwrap();
 
         assert_eq!(new.len(), 2, "all files should be new");
@@ -835,7 +896,7 @@ mod tests {
             )
             .unwrap();
 
-        let files = walk_vault(root, &[]).unwrap();
+        let files = walk_vault(root, &[], true).unwrap();
         let (new, changed, deleted) = diff_vault(&files, root, &store).unwrap();
 
         assert_eq!(new.len(), 0);
@@ -878,7 +939,7 @@ mod tests {
             )
             .unwrap();
 
-        let files = walk_vault(root, &[]).unwrap();
+        let files = walk_vault(root, &[], true).unwrap();
         let (new, changed, deleted) = diff_vault(&files, root, &store).unwrap();
 
         assert_eq!(new.len(), 0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,10 @@ enum Command {
         /// Rebuild the index from scratch.
         #[arg(long)]
         rebuild: bool,
+
+        /// Index files that `.gitignore` / `.ignore` would normally exclude.
+        #[arg(long)]
+        no_gitignore: bool,
     },
 
     /// Search the indexed vault.
@@ -444,9 +448,16 @@ async fn main() -> Result<()> {
     let data_dir = Config::data_dir()?;
 
     match cli.command {
-        Command::Index { path, rebuild } => {
+        Command::Index {
+            path,
+            rebuild,
+            no_gitignore,
+        } => {
             // Merge CLI vault path over config.
             cfg.merge_vault_path(path);
+            if no_gitignore {
+                cfg.respect_gitignore = false;
+            }
 
             // Fall back to current directory if neither CLI nor config provides a vault path.
             let vault_path = match &cfg.vault_path {


### PR DESCRIPTION
Two small fixes from open-issue triage.

### Closes #27 — trust the system CA store
Model downloads go through `ureq`, which by default trusts only bundled webpki-roots and ignores the OS trust store — so they fail behind corporate TLS-inspecting proxies with a custom CA. Enables ureq's `native-certs` feature (macOS Keychain / Linux `/etc/ssl`), which includes the standard roots plus any enterprise CA.

### Closes #23 — optional .gitignore bypass
Adds a `respect_gitignore` config option (default `true` — unchanged behavior) and an `engraph index --no-gitignore` flag. When off, the walker still skips hidden entries (`.git/`, dotfiles) and explicit excludes, but stops honoring `.gitignore`/`.ignore`.

### Verification
`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test --lib` (467 passed) all green locally. Includes a RED→GREEN regression test for the toggle.