### PR TITLE
fix(chunker): stop overlap-stride crawl that shatters long-prose files

### DIFF
--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -296,12 +296,21 @@ pub fn smart_chunk(content: &str, target_tokens: usize, overlap_pct: usize) -> V
             });
         }
 
-        // Move start forward, applying overlap
+        // Move start forward, applying overlap.
         if cut_offset >= content.len() {
             break;
         }
-        start_offset = if overlap_chars > 0 && cut_offset > overlap_chars {
-            (cut_offset - overlap_chars).max(start_offset + 1)
+        // Only step back by the overlap window when the chunk we just emitted is
+        // LARGER than that window. If the chunk is at or below overlap size,
+        // `cut_offset - overlap_chars` lands before this chunk began; the old
+        // `.max(start_offset + 1)` guard then advanced the start by a single
+        // character, re-selected the same nearby high-score break point, and
+        // crawled forward one char at a time — emitting hundreds of near-duplicate
+        // sub-chunks per file (observed: a 4.5k-word note shattered into 900+
+        // empty-heading chunks). Advancing fully to the cut guarantees real
+        // forward progress and eliminates the crawl.
+        start_offset = if overlap_chars > 0 && cut_offset > start_offset + overlap_chars {
+            cut_offset - overlap_chars
         } else {
             cut_offset
         };
@@ -693,6 +702,41 @@ mod tests {
         // Each chunk should have a snippet
         for c in &chunks {
             assert!(!c.snippet.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_smart_chunk_no_overlap_crawl() {
+        // Regression for the overlap-vs-stride crawl: when a high-score break
+        // (heading) lands within the overlap window of a chunk start, the old
+        // advance logic stepped the start forward one character at a time,
+        // re-selecting the same break and emitting hundreds of near-duplicate
+        // sub-chunks. A doc of many short headed sections must still produce a
+        // bounded, sane chunk count with no degenerate micro-chunks.
+        let mut content = String::new();
+        content.push_str("# Title\n\n");
+        for i in 0..40 {
+            content.push_str(&format!(
+                "## Section {i}\nA moderate paragraph of prose for section {i} that carries \
+                 real content but is shorter than the target chunk size, so the following \
+                 heading falls inside the overlap window.\n\n"
+            ));
+        }
+        let chunks = smart_chunk(&content, 512, 15);
+        // ~9k chars at a 2048-char target → a healthy handful of chunks, never hundreds.
+        assert!(
+            chunks.len() < 40,
+            "overlap-crawl regression: expected a bounded chunk count, got {}",
+            chunks.len()
+        );
+        // The crawl produced ~1-token fragments; real chunks are substantial.
+        for c in &chunks {
+            assert!(
+                c.text.len() > 20,
+                "degenerate micro-chunk produced ({} chars): {:?}",
+                c.text.len(),
+                c.text
+            );
         }
     }
 


### PR DESCRIPTION
## Problem

`smart_chunk` applies the overlap window even when the chunk it just emitted is *smaller* than the overlap. `cut_offset - overlap_chars` then lands before the chunk's own start, and the `.max(start_offset + 1)` guard advances the start by a **single character** — which re-selects the same nearby high-score break point and crawls forward one char at a time.

On long, heading-dense prose this shatters a file into hundreds of near-duplicate **empty-heading** micro-chunks. Observed on a real 4.5k-word note: **923 chunks, 907 of them 1-character-offset shrapnel** (e.g. `"…ystem currently authorizing…"`, `"…stem currently authorizing…"`, `"…tem currently authorizing…"`).

Impact:
1. **Retrieval breaks** — the file's signal is split below threshold across ~900 tiny fragments, so it never enters the candidate set (a unique-phrase search couldn't surface a document that is a near-perfect match for it).
2. **Index bloat** — in one vault, 451 files (11%) held **91% of all chunks** (260k of 286k). Re-chunking with this fix dropped the index 286k → 31k and cut full-rebuild time ~3.5×.

## Fix

Only step back by the overlap window when the emitted chunk is larger than that window; otherwise advance fully to the cut. Guarantees forward progress, eliminates the crawl. ~6 lines in `smart_chunk`.

## Validation

- The reproducing note re-chunks **923 → 27**; all chunks vectorize; a unique-phrase search returns it at **rank 1**.
- Adds `test_smart_chunk_no_overlap_crawl` (bounded chunk count + no degenerate micro-chunks). All 20 chunker tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)